### PR TITLE
Option mltabs to emit m-lines when string contains tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Options:
   -sl     output the opening brace on the same line (Hjson)
   -noroot omit braces for the root object (Hjson)
   -quote  quote all strings (Hjson)
+  -mltab  emit multiple lines even when the string contains tabs (Hjson)
   -rt     round trip comments (Hjson)
   -nocol  disable colors (Hjson)
 
@@ -114,6 +115,7 @@ This method produces Hjson text from a JavaScript value.
   - *space*: specifies the indentation of nested structures. If it is a number, it will specify the number of spaces to indent at each level. If it is a string (such as '\t' or '&nbsp;'), it contains the characters used to indent at each level.
   - *eol*: specifies the EOL sequence (default is set by Hjson.setEndOfLine())
   - *colors*: boolean, output ascii color codes
+  - *mltabs*: emit multi lines even if the string contains tab characters (default is false)
 
 ### Hjson.endOfLine(), .setEndOfLine(eol)
 

--- a/bin/hjson
+++ b/bin/hjson
@@ -30,6 +30,7 @@ if (args["-help"] || args["?"] || args.h) {
   console.error("  (-c | -json=compact)  output as JSON.");
   console.error("  -sl     output the opening brace on the same line (Hjson)");
   console.error("  -quote  quote all strings (Hjson)");
+  console.error("  -mltab  emit multiple lines even when the string contains tabs (Hjson)");
   console.error("  -rt     round trip comments (Hjson)");
   console.error("  -nocol  disable colors (Hjson)");
   console.error("");
@@ -77,6 +78,7 @@ function convert(text) {
     result = Hjson.stringify(obj, {
       bracesSameLine: args.sl,
       quotes: args.quote?"always":"min",
+      mltabs: !!args.mltab,
       keepWsc: args.rt,
       colors: !args.nocol && process.stdout.isTTY,
       dsf: dsf,

--- a/bin/hjson
+++ b/bin/hjson
@@ -78,7 +78,7 @@ function convert(text) {
     result = Hjson.stringify(obj, {
       bracesSameLine: args.sl,
       quotes: args.quote?"always":"min",
-      mltabs: !!args.mltab,
+      multiline: args.mltab?"with-tabs":"std",
       keepWsc: args.rt,
       colors: !args.nocol && process.stdout.isTTY,
       dsf: dsf,

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -14,8 +14,8 @@ module.exports = function($value, $opt) {
   var needsEscape = new RegExp('[\\\\\\"\x00-\x1f'+commonRange+']', 'g');
   // needsQuotes tests if the string can be written as a quoteless string (like needsEscape but without \\ and \")
   var needsQuotes = new RegExp('^\\s|^"|^\'\'\'|^#|^\\/\\*|^\\/\\/|^\\{|^\\}|^\\[|^\\]|^:|^,|\\s$|[\x00-\x1f'+commonRange+']', 'g');
-  // needsEscapeML tests if the string can be written as a multiline string (like needsEscape but without \n, \r, \\ and \")
-  var needsEscapeML = new RegExp('\'\'\'|^[\\s]+$|[\x00-\x09\x0b\x0c\x0e-\x1f'+commonRange+']', 'g');
+  // needsEscapeML tests if the string can be written as a multiline string (like needsEscape but without \n, \r, \\, \" and \t when mltabs is on)
+  var needsEscapeML = new RegExp('\'\'\'|^[\\s]+$|[\x00-'+($opt.mltabs ? '\x08' : '\x09')+'\x0b\x0c\x0e-\x1f'+commonRange+']', 'g');
   // starts with a keyword and optionally is followed by a comment
   var startsWithKeyword = new RegExp('^(true|false|null)\\s*((,|\\]|\\}|#|//|/\\*).*)?$');
   var meta =

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -15,7 +15,7 @@ module.exports = function($value, $opt) {
   // needsQuotes tests if the string can be written as a quoteless string (like needsEscape but without \\ and \")
   var needsQuotes = new RegExp('^\\s|^"|^\'\'\'|^#|^\\/\\*|^\\/\\/|^\\{|^\\}|^\\[|^\\]|^:|^,|\\s$|[\x00-\x1f'+commonRange+']', 'g');
   // needsEscapeML tests if the string can be written as a multiline string (like needsEscape but without \n, \r, \\, \" and \t when mltabs is on)
-  var needsEscapeML = new RegExp('\'\'\'|^[\\s]+$|[\x00-'+($opt.mltabs ? '\x08' : '\x09')+'\x0b\x0c\x0e-\x1f'+commonRange+']', 'g');
+  var needsEscapeML = new RegExp('\'\'\'|^[\\s]+$|[\x00-'+($opt.multiline === 'with-tabs' ? '\x08' : '\x09')+'\x0b\x0c\x0e-\x1f'+commonRange+']', 'g');
   // starts with a keyword and optionally is followed by a comment
   var startsWithKeyword = new RegExp('^(true|false|null)\\s*((,|\\]|\\}|#|//|/\\*).*)?$');
   var meta =

--- a/lib/hjson.js
+++ b/lib/hjson.js
@@ -48,6 +48,10 @@
                     "min"     - no quotes whenever possible (default)
                     "always"  - always use quotes
 
+        multiline   string, controls how multiline strings are displayed.
+                    "std"     - strings containing \n are shown ml (default)
+                    "with-tabs" - like std but allow tabs
+
         space       specifies the indentation of nested structures. If it is
                     a number, it will specify the number of spaces to indent
                     at each level. If it is a string (such as '\t' or '  '),

--- a/test/assets/extra/pass5_mltabs_result.hjson
+++ b/test/assets/extra/pass5_mltabs_result.hjson
@@ -1,0 +1,8 @@
+{
+  foo:
+    '''
+    bar	joe
+    oki	doki
+    		two tabs
+    '''
+}

--- a/test/assets/extra/pass5_mltabs_result.json
+++ b/test/assets/extra/pass5_mltabs_result.json
@@ -1,0 +1,3 @@
+{
+    "foo": "bar\tjoe\noki\tdoki\n\t\ttwo tabs"
+}

--- a/test/assets/extra/pass5_mltabs_test.json
+++ b/test/assets/extra/pass5_mltabs_test.json
@@ -1,0 +1,3 @@
+{
+    "foo": "bar\tjoe\noki\tdoki\n\t\ttwo tabs"
+}

--- a/test/assets/extra/pass5_mltabs_testmeta.hjson
+++ b/test/assets/extra/pass5_mltabs_testmeta.hjson
@@ -1,5 +1,5 @@
 { 
   options: {
-    mltabs: true
+    multiline: with-tabs
   }
 }

--- a/test/assets/extra/pass5_mltabs_testmeta.hjson
+++ b/test/assets/extra/pass5_mltabs_testmeta.hjson
@@ -1,0 +1,5 @@
+{ 
+  options: {
+    mltabs: true
+  }
+}

--- a/test/assets/testlist.txt
+++ b/test/assets/testlist.txt
@@ -68,6 +68,7 @@ pass1_test.json
 pass2_test.json
 pass3_test.json
 pass4_test.json
+extra/pass5_mltabs_test.json
 passSingle_test.hjson
 root_test.hjson
 stringify1_test.hjson

--- a/test/test.js
+++ b/test/test.js
@@ -29,11 +29,8 @@ function load(file, cr) {
 function test(name, file, isJson, inputCr, outputCr) {
   var text = load(file, inputCr);
   var shouldFail = name.substr(0, 4) === "fail";
-  var mltabs = name.indexOf("mltabs") !== -1;
-  var stringifyOpts;
-  try {
-    stringifyOpts = Hjson.parse(fs.readFileSync(path.join(rootDir, name+"_testmeta.hjson"), "utf8"));
-  } catch (x) {}
+  var metaPath = path.join(rootDir, name+"_testmeta.hjson");
+  var meta = fs.existsSync(metaPath) ? Hjson.parse(fs.readFileSync(metaPath, "utf8")) : {};
   Hjson.setEndOfLine(outputCr?"\r\n":"\n");
 
   try {
@@ -41,7 +38,7 @@ function test(name, file, isJson, inputCr, outputCr) {
 
     if (!shouldFail) {
       var text1 = JSON.stringify(data, null, 2);
-      var hjson1 = Hjson.stringify(data, stringifyOpts ? stringifyOpts.options : { emitRootBraces: true });
+      var hjson1 = Hjson.stringify(data, meta.options||{});
       var result = JSON.parse(load(name+"_result.json", inputCr));
       var text2 = JSON.stringify(result, null, 2);
       var hjson2 = load(name+"_result.hjson", outputCr);

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,11 @@ function load(file, cr) {
 function test(name, file, isJson, inputCr, outputCr) {
   var text = load(file, inputCr);
   var shouldFail = name.substr(0, 4) === "fail";
+  var mltabs = name.indexOf("mltabs") !== -1;
+  var stringifyOpts;
+  try {
+    stringifyOpts = Hjson.parse(fs.readFileSync(path.join(rootDir, name+"_testmeta.hjson"), "utf8"));
+  } catch (x) {}
   Hjson.setEndOfLine(outputCr?"\r\n":"\n");
 
   try {
@@ -36,7 +41,7 @@ function test(name, file, isJson, inputCr, outputCr) {
 
     if (!shouldFail) {
       var text1 = JSON.stringify(data, null, 2);
-      var hjson1 = Hjson.stringify(data, { emitRootBraces: true });
+      var hjson1 = Hjson.stringify(data, stringifyOpts ? stringifyOpts.options : { emitRootBraces: true });
       var result = JSON.parse(load(name+"_result.json", inputCr));
       var text2 = JSON.stringify(result, null, 2);
       var hjson2 = load(name+"_result.hjson", outputCr);


### PR DESCRIPTION
Many thanks for a great project!

This PR add support for generating triple quoted multiple lines even if the string value contains `\t` characters:

```
Hjson.stringify(value, { mltabs: true }
``` 

It is exposed on the command line as the flag `-mltab`

<img width="608" alt="hjson-mltabs" src="https://cloud.githubusercontent.com/assets/55289/21038163/6c2e1fb4-be0e-11e6-9aba-a719a6fffd04.png">

I have not figured out why the tab character would be a problem for triple quotes multiple lines.
Let me know if I missed the obvious. 

Thanks!