### PR TITLE
Multilines with tabs always

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Options:
   -sl         output the opening brace on the same line (Hjson)
   -noroot     omit braces for the root object (Hjson)
   -quote      quote all strings (Hjson)
-  -mltab      emit multiple lines even when the string contains tabs (Hjson)
+  -mltab      emit multiple lines even when the string contains tabs (Hjson, true by default)
   -rt         round trip comments (Hjson)
   -nocol      disable colors (Hjson)
   -separator  output a comma separator between elements (Hjson)
@@ -116,7 +116,9 @@ This method produces Hjson text from a JavaScript value.
   - *space*: specifies the indentation of nested structures. If it is a number, it will specify the number of spaces to indent at each level. If it is a string (such as '\t' or '&nbsp;'), it contains the characters used to indent at each level.
   - *eol*: specifies the EOL sequence (default is set by Hjson.setEndOfLine())
   - *colors*: boolean, output ascii color codes
-  - *mltabs*: emit multi lines even if the string contains tab characters (default is false)
+  - *multiline*: controls how multiline strings are displayed.
+    - "std": strings containing \n are shown ml
+    - "with-tabs": like std but allow tabs (default)
   - *separator*: boolean, output a comma separator between elements. Default false
 
 ### Hjson.endOfLine(), .setEndOfLine(eol)

--- a/bin/hjson
+++ b/bin/hjson
@@ -30,7 +30,7 @@ if (args["-help"] || args["?"] || args.h) {
   console.error("  (-c | -json=compact)  output as JSON.");
   console.error("  -sl         output the opening brace on the same line (Hjson)");
   console.error("  -quote      quote all strings (Hjson)");
-  console.error("  -mltab      emit multiple lines even when the string contains tabs (Hjson)");
+  console.error("  -mltab      emit multiple lines even when the string contains tabs (Hjson, true by default)");
   console.error("  -rt         round trip comments (Hjson)");
   console.error("  -nocol      disable colors (Hjson)");
   console.error("  -separator  output a comma separator between elements (Hjson)");

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -14,8 +14,8 @@ module.exports = function($value, $opt) {
   var needsEscape = new RegExp('[\\\\\\"\x00-\x1f'+commonRange+']', 'g');
   // needsQuotes tests if the string can be written as a quoteless string (like needsEscape but without \\ and \")
   var needsQuotes = new RegExp('^\\s|^"|^\'\'\'|^#|^\\/\\*|^\\/\\/|^\\{|^\\}|^\\[|^\\]|^:|^,|\\s$|[\x00-\x1f'+commonRange+']', 'g');
-  // needsEscapeML tests if the string can be written as a multiline string (like needsEscape but without \n, \r, \\, \" and \t when mltabs is on)
-  var needsEscapeML = new RegExp('\'\'\'|^[\\s]+$|[\x00-'+($opt.multiline === 'with-tabs' ? '\x08' : '\x09')+'\x0b\x0c\x0e-\x1f'+commonRange+']', 'g');
+  // needsEscapeML tests if the string can be written as a multiline string (like needsEscape but without \n, \r, \\, \", \t unless multines is 'std')
+  var needsEscapeML = new RegExp('\'\'\'|^[\\s]+$|[\x00-'+($opt.multiline === 'std' ? '\x09' : '\x08')+'\x0b\x0c\x0e-\x1f'+commonRange+']', 'g');
   // starts with a keyword and optionally is followed by a comment
   var startsWithKeyword = new RegExp('^(true|false|null)\\s*((,|\\]|\\}|#|//|/\\*).*)?$');
   var meta =

--- a/lib/hjson.js
+++ b/lib/hjson.js
@@ -49,8 +49,8 @@
                     "always"  - always use quotes
 
         multiline   string, controls how multiline strings are displayed.
-                    "std"     - strings containing \n are shown ml (default)
-                    "with-tabs" - like std but allow tabs
+                    "std"     - strings containing \n are shown ml
+                    "with-tabs" - like std but allow tabs (default)
 
         space       specifies the indentation of nested structures. If it is
                     a number, it will specify the number of spaces to indent

--- a/test/assets/strings_result.hjson
+++ b/test/assets/strings_result.hjson
@@ -1,7 +1,7 @@
 {
   text1: This is a valid string value.
   text2: a \ is just a \
-  text3: "You need quotes\tfor escapes"
+  text3: '''You need quotes	for escapes'''
   text4a: " untrimmed "
   text4b: " untrimmed"
   text4c: "untrimmed "


### PR DESCRIPTION
This patch will remove the ability to not emit a multiline when there is a tab character.

Ref: https://github.com/hjson/hjson-js/pull/15#issuecomment-268094522

I broke it down into 2 commits: the first commit sticks to the suggestion: emit multiline even if there is a tab by default.
The second commit goes a step further.

Let me know if you would rather stick to the first commit alone.