### PR TITLE
New option to format arrays of simple values (strings, numbers, bools) on a single line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This method produces Hjson text from a JavaScript value.
 - *options*: object
   - *keepWsc*: boolean, keep white space. See parse.
   - *bracesSameLine*: boolean, makes braces appear on the same line as the key name. Default false.
+  - *inlineSimple*: boolean, simple array-elements are comma separated on a single line. Default false.
   - *emitRootBraces*: boolean, show braces for the root object. Default true.
   - *quotes*: string, controls how strings are displayed. (setting separator implies "strings")
     - "min": no quotes whenever possible (default)

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -43,7 +43,7 @@ module.exports = function(data, opt) {
     bracesSameLine = opt.bracesSameLine;
     inlineSimple = opt.inlineSimple;
     quoteKeys = opt.quotes === 'all' || opt.quotes === 'keys';
-    quoteStrings = opt.quotes === 'all' || opt.quotes === 'strings' || opt.separator === true;
+    quoteStrings = opt.quotes === 'all' || opt.quotes === 'strings' || opt.separator === true || inlineSimple;
     if (quoteStrings || opt.multiline == 'off') multiline = 0;
     else multiline = opt.multiline == 'no-tabs' ? 2 : 1;
     separator = opt.separator === true ? ',' : '';
@@ -244,8 +244,8 @@ module.exports = function(data, opt) {
 
           for (i = 0, length = value.length; i < length; i++) {
             if (isSimple) {
-				var t = typeof value[i];
-				if (!(t === 'string' || t === 'number' || t === 'boolean')) isSimple = false;
+			  var t = typeof value[i];
+			  if (!(t === 'string' || t === 'number' || t === 'boolean')) isSimple = false;
             }
 
             if (comments) {

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -12,7 +12,7 @@ module.exports = function(data, opt) {
   var indent = '  ';
   var keepComments = false;
   var bracesSameLine = false;
-  var inlineSimple = true;
+  var inlineSimple = false;
   var quoteKeys = false;
   var quoteStrings = false;
   var multiline = 1; // std=1, no-tabs=2, off=0

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -244,8 +244,8 @@ module.exports = function(data, opt) {
 
           for (i = 0, length = value.length; i < length; i++) {
             if (isSimple) {
-			  var t = typeof value[i];
-			  if (!(t === 'string' || t === 'number' || t === 'boolean')) isSimple = false;
+              var t = typeof value[i];
+              if (!(t === 'string' || t === 'number' || t === 'boolean')) isSimple = false;
             }
 
             if (comments) {

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -12,6 +12,7 @@ module.exports = function(data, opt) {
   var indent = '  ';
   var keepComments = false;
   var bracesSameLine = false;
+  var inlineSimple = true;
   var quoteKeys = false;
   var quoteStrings = false;
   var multiline = 1; // std=1, no-tabs=2, off=0
@@ -40,6 +41,7 @@ module.exports = function(data, opt) {
     if (opt.eol === '\n' || opt.eol === '\r\n') eol = opt.eol;
     keepComments = opt.keepWsc;
     bracesSameLine = opt.bracesSameLine;
+    inlineSimple = opt.inlineSimple;
     quoteKeys = opt.quotes === 'all' || opt.quotes === 'keys';
     quoteStrings = opt.quotes === 'all' || opt.quotes === 'strings' || opt.separator === true;
     if (quoteStrings || opt.multiline == 'off') multiline = 0;
@@ -230,6 +232,7 @@ module.exports = function(data, opt) {
         var eolGap = eol + gap;
         var prefix = noIndent || bracesSameLine ? '' : eolMind;
         var partial = [];
+        var isSimple = inlineSimple;
 
         var i, length; // loop
         var k, v; // key, value
@@ -240,6 +243,11 @@ module.exports = function(data, opt) {
           // for non-JSON values.
 
           for (i = 0, length = value.length; i < length; i++) {
+            if (isSimple) {
+				var t = typeof value[i];
+				if (!(t === 'string' || t === 'number' || t === 'boolean')) isSimple = false;
+            }
+
             if (comments) {
               c = comments.a[i]||[];
               ca = commentOnThisLine(c[1]);
@@ -262,6 +270,7 @@ module.exports = function(data, opt) {
 
           if (comments) v = prefix + wrap(token.arr, partial.join(''));
           else if (partial.length === 0) v = wrap(token.arr, '');
+          else if (isSimple) v = prefix + wrap(token.arr, ' ' + partial.join(', ') + ' ');
           else v = prefix + wrap(token.arr, eolGap + partial.join(eolGap) + eolMind);
         } else {
           // Otherwise, iterate through all of the keys in the object.


### PR DESCRIPTION
I added a simple option "inlineSimple" which formats arrays of simple values comma-separated on a single line. This can improve readability in some cases.

This
```
[
   "value1"
   "value2"
   "value3"
  10
  11
]
```
with inlineSimple=true is formatted as:
```
[ "value1", "value2", "value2", 10, 11 ]
```