### PR TITLE
npmignore tests in test/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ _*
 .travis.yml
 sample/
 coverage/
+test/


### PR DESCRIPTION
Before change:

```bash
$ npm pack
```

```
-rw-rw-r--    1 dan  staff    79K May 15 11:38 hjson-2.4.1.tgz
```

After change:

```bash
$ npm pack
```

```
-rw-rw-r--    1 dan  staff    34K May 15 11:41 hjson-2.4.1.tgz
```

Uncompressed, the `test/` directory is 552KB out of 716K (77%) from a normal `npm install hjson`.

This change will exclude over a half of a megabyte for each npm install of this module.