### PR TITLE
Require quoting for keys containing At Sign

### DIFF
--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -111,7 +111,7 @@ module.exports = function(data, opt) {
     '"' : '"',
     '\\': '\\'
   };
-  var needsEscapeName = /[,\{\[\}\]\s:#"']|\/\/|\/\*/;
+  var needsEscapeName = /[,\{\[\}\]\s@:#"']|\/\/|\/\*/;
   var gap = '';
   //
   var wrapLen = 0;

--- a/lib/hjson-stringify.js
+++ b/lib/hjson-stringify.js
@@ -111,7 +111,7 @@ module.exports = function(data, opt) {
     '"' : '"',
     '\\': '\\'
   };
-  var needsEscapeName = /[,\{\[\}\]\s@:#"']|\/\/|\/\*/;
+  var needsEscapeName = /[,\{\[\}\]\s@\-:#"']|\/\/|\/\*/;
   var gap = '';
   //
   var wrapLen = 0;


### PR DESCRIPTION
Currently when minimal quoting is specified, keys containing @ sign are not quoted, but then should be.